### PR TITLE
change issue link to dysinger's repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PureScript Mode for Emacs
 This is the PureScript mode package for Emacs.
 
 To report problems or suggestions, please
-[open an issue](https://github.com/purescript/purescript-mode/issues?state=open)
+[open an issue](https://github.com/dysinger/purescript-mode/issues?state=open)
 in the issue tracker.
 
 Below is a brief setup guide.


### PR DESCRIPTION
There is no `purescript/purescript-mode` repo on GitHub, so change the link to point at @dysinger's repo.

However! @dysinger doesn't have issues enabled for this repo, so that will have to be rectified before this PR is merged...

Not sure what's actually intended, but obviously I can't file an issue to try to get it sorted out. :)