### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ versions.
     ```el
     (add-to-list 'load-path "~/lib/emacs/purescript-mode/")
     (require 'purescript-mode-autoloads)
-    (add-to-list 'Info-default-directory-list "~/lib/emacs/purescript-mode/")
+    (add-to-list 'Info-additional-directory-list "path-to-purescript-mode/")
     ```
 
 -   After updating your purescript-mode working directory, you need to


### PR DESCRIPTION
Use `Info-additional-directory-list` which is way more reliable and in fact recommended in Emacs docs. Initialising Info pages from `Info-default-directory-list` can very easily by overwritten by other machinery (say if you have INFOPATH env variable). Please, see docs for `Info-default-directory-list`. Regards