### PR TITLE
Fix git repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ versions.
 
 ### Installation from Git
 
--   `git clone https://github.com/purescript/purescript-mode.git` into a
+-   `git clone https://github.com/dysinger/purescript-mode.git` into a
     suitable directory, e.g. `~/lib/emacs/purescript-mode/` where `~`
     stands for your home directory.
 


### PR DESCRIPTION
Let installation notes reference the repository https://github.com/dysinger/purescript-mode.git, not the repository https://github.com/purescript/purescript-mode.git.
