### PR TITLE
avoid setting eldoc-documentation-function to undefined value

### DIFF
--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -323,9 +323,6 @@ see documentation for that variable for more details."
   (set (make-local-variable 'comment-end-skip) "[ \t]*\\(-}\\|\\s>\\)")
   (set (make-local-variable 'parse-sexp-ignore-comments) nil)
   (set (make-local-variable 'indent-line-function) 'purescript-mode-suggest-indent-choice)
-  ;; Set things up for eldoc-mode.
-  (set (make-local-variable 'eldoc-documentation-function)
-       'purescript-doc-current-info)
   ;; Set things up for font-lock.
   (set (make-local-variable 'font-lock-defaults)
        '(purescript-font-lock-choose-keywords


### PR DESCRIPTION
The function purescript-doc-current-info is not defined so this would
previously cause error messages whenever eldoc was triggered.

This functionality is not necessary since it is provided by psc-ide-mode.

<img width="584" alt="screen shot 2016-10-12 at 1 00 48 pm" src="https://cloud.githubusercontent.com/assets/43347/19305950/07af3588-907c-11e6-9e7b-e872cf857cf7.png">